### PR TITLE
Improve Severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.3 / 2013-12-17
+[FEATURE] Tidy up formatting to have positional padding 
+
 1.0.2 / 2013-12-16
 [FEATURE] By default, rotate logs daily 
 

--- a/lib/filum/log_formatter.rb
+++ b/lib/filum/log_formatter.rb
@@ -3,7 +3,7 @@ require 'logger'
 module Filum
   class LogFormatter < Logger::Formatter
     def call(severity, timestamp, progname, msg)
-      "#{timestamp} #{formatted_thread_id} [#{formatted_context_id}] #{severity} | #{formatted_calling_file_and_line} | #{msg}\n"
+      "#{timestamp} #{formatted_thread_id} [#{formatted_context_id}] #{severity.to_s.ljust(5)} | #{formatted_calling_file_and_line} | #{msg}\n"
     end
 
     private

--- a/lib/filum/log_formatter.rb
+++ b/lib/filum/log_formatter.rb
@@ -3,7 +3,7 @@ require 'logger'
 module Filum
   class LogFormatter < Logger::Formatter
     def call(severity, timestamp, progname, msg)
-      "#{timestamp} thread_id-#{Thread.current.object_id} [#{formatted_context_id}] #{severity} | #{formatted_calling_file_and_line} | #{msg}\n"
+      "#{timestamp} #{formatted_thread_id} [#{formatted_context_id}] #{severity} | #{formatted_calling_file_and_line} | #{msg}\n"
     end
 
     private
@@ -23,9 +23,17 @@ module Filum
       file = "#{file[0,truncated_filename_length]}..." if file.length >= filename_length 
       "#{file}:#{line.ljust(3)}".ljust(filename_length + 4)
     end
+    
+    def formatted_thread_id
+      "t-#{thread_id}".ljust(12)
+    end
 
     def calling_code
       caller[5]
+    end
+
+    def thread_id
+      Thread.current.object_id
     end
   end
 end

--- a/lib/filum/version.rb
+++ b/lib/filum/version.rb
@@ -1,3 +1,3 @@
 module Filum
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/test/unit/log_formatter_test.rb
+++ b/test/unit/log_formatter_test.rb
@@ -4,7 +4,7 @@ module Filum
   
   class LogFormatterTest < Minitest::Test
     
-    def test_string_format
+    def test_string_format_contains_correct_when_padding_stripped_out
       formatter = Filum::LogFormatter.new
       severity = "SEV123"
       timestamp = "Timestamp123"
@@ -12,12 +12,37 @@ module Filum
       context_id = "context_id"
       object_id = Thread.current.object_id
       file_and_line = "file_and_line"
-      formatter.stubs(calling_file_and_line: file_and_line)
+      formatter.stubs(formatted_calling_file_and_line: file_and_line)
       Thread.current[:context_id] = context_id
 
       output = formatter.call(severity, timestamp, nil, msg)
-      desired = "#{timestamp} thread_id-#{object_id} [#{context_id}] #{severity} | #{file_and_line} | #{msg}\n"
-      assert_equal desired.strip.hex, output.strip.hex
+      desired = "#{timestamp} t-#{object_id} [#{context_id}] #{severity} | #{file_and_line} | #{msg}\n"
+      assert_equal desired, output.gsub(/[ ]+/, ' ')
+    end
+    
+    def test_severity_should_pad_to_5_chars
+      formatter = Filum::LogFormatter.new
+      severity = "SEV"
+      timestamp = "Timestamp123"
+      msg = "My Message"
+      output = formatter.call(severity, timestamp, nil, msg)
+      actual_severity_field = output.match(/SEV\s+\|/)[0]
+      assert_equal "SEV   |", actual_severity_field
+    end
+    
+    def test_can_format_with_nil_severity
+      formatter = Filum::LogFormatter.new
+      formatter.call(nil, "timestamp", nil, "msg")
+    end
+    
+    def test_can_format_with_nil_timestamp
+      formatter = Filum::LogFormatter.new
+      formatter.call("SEV", nil, nil, "msg")
+    end
+    
+    def test_can_format_with_nil_msg
+      formatter = Filum::LogFormatter.new
+      formatter.call("SEV", "timestamp", nil, nil)
     end
 
     def test_call_calls_formatted_context_id
@@ -104,6 +129,13 @@ module Filum
       formatter.stubs(thread_id: "0123456")
       output = formatter.send(:formatted_thread_id)
       assert_equal "t-0123456   ", output
+    end
+    
+    def test_formatted_thread_id_should_overflow_not_trim
+      formatter = Filum::LogFormatter.new
+      formatter.stubs(thread_id: "01234567890")
+      output = formatter.send(:formatted_thread_id)
+      assert_equal "t-01234567890", output
     end
     
   end

--- a/test/unit/log_formatter_test.rb
+++ b/test/unit/log_formatter_test.rb
@@ -92,5 +92,19 @@ module Filum
       output = formatter.send(:formatted_calling_file_and_line)
       assert_equal "foobar.txt:30           ", output
     end
+    
+    def test_call_calls_formatted_thread_id
+      formatter = Filum::LogFormatter.new
+      formatter.expects(:formatted_thread_id)
+      formatter.call("", "", "", "")
+    end
+    
+    def test_formatted_thread_id_should_pad
+      formatter = Filum::LogFormatter.new
+      formatter.stubs(thread_id: "0123456")
+      output = formatter.send(:formatted_thread_id)
+      assert_equal "t-0123456   ", output
+    end
+    
   end
 end


### PR DESCRIPTION
Our desire with Filum is to have readable logs with columnar padding). I propose that we modify the padding of the severity column to the longest value we use. E.g. so that ERROR and INFO logs align.
